### PR TITLE
Use Python importlib for compatibility with Django 1.9

### DIFF
--- a/djmoney_rates/settings.py
+++ b/djmoney_rates/settings.py
@@ -15,8 +15,10 @@ django-money-rates settings, checking for user settings first, then falling
 back to the defaults.
 """
 
+import importlib
+
 from django.conf import settings
-from django.utils import importlib, six
+from django.utils import six
 
 
 USER_SETTINGS = getattr(settings, 'DJANGO_MONEY_RATES', None)


### PR DESCRIPTION
When upgrading to Django 1.9, I had some issues with `django-money-rates`, that were related to `importlib` usage, which was deprecated in Django 1.9.

The fix is a one liner, but is pretty important IMO. Please check the PO and let me know if you have any questions.
