### PR TITLE
Use minimum version numbers, not exact ones, in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     test_suite='runtests',
     install_requires=[
-        'py-moneyed==0.6.0'
+        'py-moneyed>=0.6.0'
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Otherwise people can't install the library easily in the context of their projects.